### PR TITLE
Fix emoji card expand animation

### DIFF
--- a/src/components/cardEmoji.vue
+++ b/src/components/cardEmoji.vue
@@ -2,7 +2,7 @@
     <div class="card">
         <div class="card-body text-center h2" data-toggle="collapse" :href="`#desc-${animeId}`" aria-expanded="false">
             {{animeEmoji}}
-            <div class="card-hidden text-center collapse" v-bind:id="`desc-${animeId}`">
+            <div class="text-center collapse" v-bind:id="`desc-${animeId}`">
                 <div class="card-title h5">
                     {{animeName}} ({{animeYear}})
                 </div>
@@ -26,10 +26,8 @@ export default {
 .card{
     user-select: none;
 }
-.card-hidden {
-    padding-top: 1.5rem;
-}
 .card-title {
+    margin-top: 1.5rem;
     margin-bottom: 0;
 }
 .card-body {


### PR DESCRIPTION
The issue was that JQuery was not taking into account the padding on the expanding/collapsing element. Moving it to a margin-top on the Anime name element fixes this.

Before:
![Screen Recording 2019-10-02 at 12 56 AM](https://user-images.githubusercontent.com/6721376/66019021-77b0dc80-e4af-11e9-950e-1f6e8a080268.gif)

After:
![Screen Recording 2019-10-02 at 12 55 AM](https://user-images.githubusercontent.com/6721376/66018995-610a8580-e4af-11e9-9f63-82577640ad39.gif)
